### PR TITLE
Add missing React TypeScript definitions to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "20.14.2",
+    "@types/react": "18.2.74",
+    "@types/react-dom": "18.2.24",
     "prisma": "5.17.0",
     "tsx": "4.19.1",
     "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- add the missing React and Node type packages to the devDependencies so Next.js no longer tries to auto-install them during builds

## Testing
- npm run build *(fails locally because the environment blocks installing the new @types packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e12a8a6ea4832e9e0d32e94b69ecb8