### PR TITLE
Add TypeScript types to fix Next.js build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.env
+.prisma
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "20.14.9",
+    "@types/react": "18.2.66",
     "prisma": "5.17.0",
     "tsx": "4.19.1",
     "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- add the missing `@types/node` and `@types/react` dev dependencies required by Next.js when using TypeScript
- add a `.gitignore` to keep build artifacts and dependency folders out of version control

## Testing
- npm run build *(fails locally because packages cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12c37bf14832e9885423fe22d97b6