### PR TITLE
Fix inspection detail page typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "prisma": "5.17.0",
     "tsx": "4.19.1",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "@types/node": "20.14.9",
+    "@types/react": "18.3.3"
   }
 }

--- a/src/app/assets/[id]/page.tsx
+++ b/src/app/assets/[id]/page.tsx
@@ -1,35 +1,45 @@
 import { prisma } from "@/lib/prisma";
 import InspectionForm from "@/components/InspectionForm";
+import type { Inspection } from "@prisma/client";
 
 export default async function AssetDetail({ params }: { params: { id: string } }) {
   const id = Number(params.id);
   const asset = await prisma.asset.findUnique({ where: { id } });
-  const inspections = await prisma.inspection.findMany({ where: { assetId: id }, orderBy: { id: "desc" } });
+  const inspections: Inspection[] = await prisma.inspection.findMany({
+    where: { assetId: id },
+    orderBy: { id: "desc" },
+  });
 
   if (!asset) return <div>Actif introuvable.</div>;
 
   return (
-     <div className="grid" style={{gap:16}}>
+    <div className="grid" style={{ gap: 16 }}>
       <div className="card">
         <div className="small">{asset.assetId} · UID {asset.uid}</div>
-        <h2 style={{fontSize:20, fontWeight:700}}>{asset.name}</h2>
-        <div className="small">{asset.category} · {asset.make ?? ""} {asset.model ?? ""}</div>
-        <div>Compteur: {asset.meterValue ?? "—"} {asset.meterType ?? ""}</div>
+        <h2 style={{ fontSize: 20, fontWeight: 700 }}>{asset.name}</h2>
+        <div className="small">
+          {asset.category} · {asset.make ?? ""} {asset.model ?? ""}
+        </div>
+        <div>
+          Compteur: {asset.meterValue ?? "—"} {asset.meterType ?? ""}
+        </div>
       </div>
 
       <section className="grid">
-        <h3 style={{fontWeight:600}}>Nouvelle inspection</h3>
+        <h3 style={{ fontWeight: 600 }}>Nouvelle inspection</h3>
         <InspectionForm assetId={asset.id} defaultMeter={asset.meterValue ?? undefined} />
       </section>
 
       <section className="grid">
-        <h3 style={{fontWeight:600}}>Historique des inspections</h3>
+        <h3 style={{ fontWeight: 600 }}>Historique des inspections</h3>
         <div className="grid">
-          {inspections.map((i) => (
-            <div key={i.id} className="card" style={{fontSize:14}}>
-              <div className="small">{new Date(i.createdAt).toLocaleString()}</div>
-              <div>Statut: {i.status}</div>
-              {i.meterValue !== null && <div>Compteur: {i.meterValue}</div>}
+          {inspections.map((inspection) => (
+            <div key={inspection.id} className="card" style={{ fontSize: 14 }}>
+              <div className="small">
+                {new Date(inspection.createdAt).toLocaleString()}
+              </div>
+              <div>Statut: {inspection.status}</div>
+              {inspection.meterValue !== null && <div>Compteur: {inspection.meterValue}</div>}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add the missing React and Node type packages to the dev dependencies
- annotate the inspections query result so the map callback parameter is strongly typed
- tidy inline styles on the asset detail page for readability

## Testing
- npm run build *(fails: Next.js cannot install @types/react and @types/node because the environment blocks registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d3709b4832ea698f75f59c0a868