### PR TITLE
Fix Prisma generation during install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+*.log

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "seed": "tsx scripts/seed.ts",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "5.17.0",
@@ -16,6 +17,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "20.14.11",
+    "@types/react": "18.2.37",
     "prisma": "5.17.0",
     "tsx": "4.19.1",
     "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- add a postinstall script to ensure `prisma generate` runs during deployments
- add the React and Node type packages required by Next.js type checking
- commit a `.gitignore` so local build artifacts stay out of the repository

## Testing
- npm run build *(fails in container: npm 403 Forbidden when attempting to install @types packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e15324e3b0832e9b1927cacc8e0655