### PR TITLE
Add missing TypeScript type dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.env*
+dist
+out
+coverage
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/node": "20.14.2",
+    "@types/react": "18.2.66",
     "prisma": "5.17.0",
     "tsx": "4.19.1",
     "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- add the required `@types/node` and `@types/react` packages so the Next.js TypeScript build passes
- add a `.gitignore` to keep generated artifacts such as `node_modules` out of version control

## Testing
- npm run build *(fails in the container because the environment cannot install the new type packages automatically)*

------
https://chatgpt.com/codex/tasks/task_e_68e156e87834832e885a769247d45ea6