### PR TITLE
Fix implicit any errors in asset pages

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/app/assets/[id]/page.tsx
+++ b/src/app/assets/[id]/page.tsx
@@ -4,7 +4,11 @@ import InspectionForm from "@/components/InspectionForm";
 export default async function AssetDetail({ params }: { params: { id: string } }) {
   const id = Number(params.id);
   const asset = await prisma.asset.findUnique({ where: { id } });
-  const inspections = await prisma.inspection.findMany({ where: { assetId: id }, orderBy: { id: "desc" } });
+  type Inspection = Awaited<ReturnType<typeof prisma.inspection.findMany>>[number];
+  const inspections: Inspection[] = await prisma.inspection.findMany({
+    where: { assetId: id },
+    orderBy: { id: "desc" },
+  });
 
   if (!asset) return <div>Actif introuvable.</div>;
 
@@ -25,11 +29,11 @@ export default async function AssetDetail({ params }: { params: { id: string } }
       <section className="grid">
         <h3 style={{fontWeight:600}}>Historique des inspections</h3>
         <div className="grid">
-          {inspections.map((i) => (
-            <div key={i.id} className="card" style={{fontSize:14}}>
-              <div className="small">{new Date(i.createdAt).toLocaleString()}</div>
-              <div>Statut: {i.status}</div>
-              {i.meterValue !== null && <div>Compteur: {i.meterValue}</div>}
+          {inspections.map((inspection: Inspection) => (
+            <div key={inspection.id} className="card" style={{fontSize:14}}>
+              <div className="small">{new Date(inspection.createdAt).toLocaleString()}</div>
+              <div>Statut: {inspection.status}</div>
+              {inspection.meterValue !== null && <div>Compteur: {inspection.meterValue}</div>}
             </div>
           ))}
         </div>

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -2,17 +2,18 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 
 export default async function AssetsPage() {
-  const assets = await prisma.asset.findMany({ orderBy: { id: "asc" } });
+  type Asset = Awaited<ReturnType<typeof prisma.asset.findMany>>[number];
+  const assets: Asset[] = await prisma.asset.findMany({ orderBy: { id: "asc" } });
   return (
     <div className="grid">
       <h2 style={{fontSize:18, fontWeight:600}}>Actifs</h2>
       <div className="grid grid2">
-        {assets.map((a) => (
-          <Link key={a.id} href={`/assets/${a.id}`} className="card">
-            <div className="small">{a.assetId} · UID {a.uid}</div>
-            <div style={{fontWeight:600}}>{a.name}</div>
-            <div className="small">{a.category} · {a.make ?? ""} {a.model ?? ""}</div>
-            <div className="small">Statut: {a.status}</div>
+        {assets.map((asset: Asset) => (
+          <Link key={asset.id} href={`/assets/${asset.id}`} className="card">
+            <div className="small">{asset.assetId} · UID {asset.uid}</div>
+            <div style={{fontWeight:600}}>{asset.name}</div>
+            <div className="small">{asset.category} · {asset.make ?? ""} {asset.model ?? ""}</div>
+            <div className="small">Statut: {asset.status}</div>
           </Link>
         ))}
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,9 @@
     "paths": {
       "@/lib/*": ["src/lib/*"],
       "@/components/*": ["src/components/*"]
-    }
+    },
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add explicit Prisma result typing on the asset list and detail pages to avoid implicit any errors during builds
- keep Next.js generated TypeScript configuration updates that enable the Next plugin and .next type inclusion
- retain the autogenerated guidance comment in next-env.d.ts

## Testing
- npm run build *(fails: Prisma schema validation rejects Json fields for the SQLite datasource, preventing `prisma generate` and the build from completing)*

------
https://chatgpt.com/codex/tasks/task_e_68e50effe59c832e9cec37d5b70f5ccf