### PR TITLE
Normalize inspection JSON handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+prisma/*.db

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "seed": "tsx scripts/seed.ts",
     "prisma:studio": "prisma studio"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,8 +34,8 @@ model Inspection {
   assetId    Int
   asset      Asset    @relation(fields: [assetId], references: [id])
   meterValue Int?
-  checklist  Json
-  photos     Json?
+  checklist  String
+  photos     String?
   status     String
   createdBy  String
   createdAt  DateTime @default(now())

--- a/src/app/api/inspections/route.ts
+++ b/src/app/api/inspections/route.ts
@@ -1,24 +1,52 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+function normalizeChecklist(value: unknown): Record<string, boolean> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const entries = Object.entries(value).map(([key, raw]) => [key, raw === true]);
+  return Object.fromEntries(entries);
+}
+
+function isJsonSerializable(value: unknown): value is object | unknown[] | string | number | boolean | null {
+  if (value === null) return true;
+  if (Array.isArray(value)) return value.every(isJsonSerializable);
+  if (typeof value === "object") {
+    return Object.values(value).every(isJsonSerializable);
+  }
+  return ["string", "number", "boolean"].includes(typeof value);
+}
+
 export async function POST(req: NextRequest) {
   const data = await req.json();
   const { assetId, status, checklist, meterValue, createdBy, photos } = data;
-  if (!assetId || !status || !checklist || !createdBy) {
+  const assetIdNumber = typeof assetId === "number" ? assetId : Number(assetId);
+
+  const normalizedChecklist = normalizeChecklist(checklist);
+
+  if (!Number.isInteger(assetIdNumber) || !status || !normalizedChecklist || !createdBy) {
     return NextResponse.json({ error: "Champs requis: assetId, status, checklist, createdBy" }, { status: 400 });
   }
+
   const created = await prisma.inspection.create({
     data: {
-      assetId,
+      assetId: assetIdNumber,
       status,
-      checklist,
+      checklist: JSON.stringify(normalizedChecklist),
       meterValue: typeof meterValue === "number" ? meterValue : null,
       createdBy,
-      photos: photos ?? null,
+      photos: isJsonSerializable(photos) ? JSON.stringify(photos) : null,
     },
   });
   if (typeof meterValue === "number") {
-    await prisma.asset.update({ where: { id: assetId }, data: { meterValue } });
+    await prisma.asset.update({ where: { id: assetIdNumber }, data: { meterValue } });
   }
-  return NextResponse.json(created, { status: 201 });
+  return NextResponse.json(
+    {
+      ...created,
+    },
+    { status: 201 }
+  );
 }

--- a/src/app/assets/[id]/page.tsx
+++ b/src/app/assets/[id]/page.tsx
@@ -1,15 +1,23 @@
+export const dynamic = "force-dynamic";
+
 import { prisma } from "@/lib/prisma";
 import InspectionForm from "@/components/InspectionForm";
+
+type Inspection = Awaited<ReturnType<typeof prisma.inspection.findMany>>[number];
 
 export default async function AssetDetail({ params }: { params: { id: string } }) {
   const id = Number(params.id);
   const asset = await prisma.asset.findUnique({ where: { id } });
-  const inspections = await prisma.inspection.findMany({ where: { assetId: id }, orderBy: { id: "desc" } });
+  const rawInspections = await prisma.inspection.findMany({
+    where: { assetId: id },
+    orderBy: { id: "desc" },
+  });
+  const inspections: Inspection[] = rawInspections;
 
   if (!asset) return <div>Actif introuvable.</div>;
 
   return (
-     <div className="grid" style={{gap:16}}>
+    <div className="grid" style={{gap:16}}>
       <div className="card">
         <div className="small">{asset.assetId} · UID {asset.uid}</div>
         <h2 style={{fontSize:20, fontWeight:700}}>{asset.name}</h2>
@@ -25,11 +33,16 @@ export default async function AssetDetail({ params }: { params: { id: string } }
       <section className="grid">
         <h3 style={{fontWeight:600}}>Historique des inspections</h3>
         <div className="grid">
-          {inspections.map((i) => (
+          {inspections.map((i: Inspection) => (
             <div key={i.id} className="card" style={{fontSize:14}}>
               <div className="small">{new Date(i.createdAt).toLocaleString()}</div>
               <div>Statut: {i.status}</div>
               {i.meterValue !== null && <div>Compteur: {i.meterValue}</div>}
+              {Object.entries(i.checklist).map(([item, ok]) => (
+                <div key={item} className="small">
+                  {item}: <b>{ok ? "OK" : "À vérifier"}</b>
+                </div>
+              ))}
             </div>
           ))}
         </div>

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,5 +1,9 @@
+export const dynamic = "force-dynamic";
+
 import Link from "next/link";
 import { prisma } from "@/lib/prisma";
+
+type Asset = Awaited<ReturnType<typeof prisma.asset.findMany>>[number];
 
 export default async function AssetsPage() {
   const assets = await prisma.asset.findMany({ orderBy: { id: "asc" } });
@@ -7,7 +11,7 @@ export default async function AssetsPage() {
     <div className="grid">
       <h2 style={{fontSize:18, fontWeight:600}}>Actifs</h2>
       <div className="grid grid2">
-        {assets.map((a) => (
+        {assets.map((a: Asset) => (
           <Link key={a.id} href={`/assets/${a.id}`} className="card">
             <div className="small">{a.assetId} · UID {a.uid}</div>
             <div style={{fontWeight:600}}>{a.name}</div>

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,11 +1,67 @@
 import { PrismaClient } from "@prisma/client";
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient };
+const defaultDatabaseUrl = "file:./dev.db";
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = defaultDatabaseUrl;
+}
 
-export const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({
+type ExtendedPrismaClient = ReturnType<typeof createPrismaClient>;
+
+const globalForPrisma = globalThis as unknown as { prisma?: ExtendedPrismaClient };
+
+function parseChecklist(checklist: string | null): Record<string, boolean> {
+  if (!checklist) return {};
+  try {
+    const parsed = JSON.parse(checklist) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+    const result: Record<string, boolean> = {};
+    for (const [key, raw] of Object.entries(parsed as Record<string, unknown>)) {
+      result[key] = raw === true;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function parsePhotos(photos: string | null): unknown {
+  if (!photos) return null;
+  try {
+    return JSON.parse(photos) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function createPrismaClient() {
+  const base = new PrismaClient({
     log: ["error", "warn"],
   });
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+  return base.$extends({
+    result: {
+      inspection: {
+        checklist: {
+          needs: { checklist: true },
+          compute({ checklist }): Record<string, boolean> {
+            return parseChecklist(checklist);
+          },
+        },
+        photos: {
+          needs: { photos: true },
+          compute({ photos }): unknown {
+            return parsePhotos(photos);
+          },
+        },
+      },
+    },
+  });
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -15,10 +19,26 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/lib/*": ["src/lib/*"],
-      "@/components/*": ["src/components/*"]
-    }
+      "@/lib/*": [
+        "src/lib/*"
+      ],
+      "@/components/*": [
+        "src/components/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- normalize inspection checklist payloads before persisting and ensure asset IDs are numeric in the API handler
- extend the Prisma client so inspection checklist and photo fields are returned as parsed JSON objects everywhere
- simplify the asset detail page by relying on the Prisma extension for checklist data instead of manual parsing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e511698d0c832eab3672f9f97423a2